### PR TITLE
使用phpstorm进行单元测试会报错

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,4 +9,4 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/nano/blob/master/LICENSE
  */
-require_once 'vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
使用phpstorm进行单元测试，会报错failed to open stream: No such file or directory 
/Users/xxx/Documents/study/clion/php-7.3.19/work/bin/php /Users/xxx/Documents/www/learnphp/hyperf/nano/vendor/bin/co-phpunit --configuration /Users/xxx/Documents/www/learnphp/hyperf/nano/phpunit.xml --filter "/(::testDi)( .*)?$/" HyperfTest\Nano\Cases\Http\ContainerTest /Users/xxx/Documents/www/learnphp/hyperf/nano/tests/Cases/Http/ContainerTest.php --teamcity
PHP Warning:  require_once(vendor/autoload.php): failed to open stream: No such file or directory in /Users/xxx/Documents/www/learnphp/hyperf/nano/tests/bootstrap.php on line 12
