### PR TITLE
Master

### DIFF
--- a/src/ContainerProxy.php
+++ b/src/ContainerProxy.php
@@ -68,4 +68,9 @@ class ContainerProxy implements BoundInterface, ContainerInterface
     {
         return $this->container->set($name, $entry);
     }
+
+    public function unbind(string $name)
+    {
+        return $this->container->unbind($name);
+    }
 }


### PR DESCRIPTION
解决nano运行报Class Hyperf\Nano\ContainerProxy contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Hyperf\Contract\ContainerInterface::unbind)