### PR TITLE
Adds test for swoole v4.8.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ ubuntu-latest ]
         php-version: [ '8.0', '8.1' ]
         engine: [ 'swoole' ]
-        swoole-version: [ 'v4.6.7', 'v4.7.1', 'v4.8.10', 'master' ]
+        swoole-version: [ 'v4.6.7', 'v4.7.1', 'v4.8.11', 'master' ]
         exclude:
           - php-version: '8.1'
             swoole-version: 'v4.6.7'

--- a/src/Factory/ParameterParser.php
+++ b/src/Factory/ParameterParser.php
@@ -19,17 +19,14 @@ use Psr\Container\ContainerInterface;
 
 class ParameterParser
 {
-    private ContainerInterface $container;
-
     private NormalizerInterface $normalizer;
 
     private ?ClosureDefinitionCollectorInterface $closureDefinitionCollector = null;
 
     private ?MethodDefinitionCollectorInterface $methodDefinitionCollector = null;
 
-    public function __construct(ContainerInterface $container)
+    public function __construct(private ContainerInterface $container)
     {
-        $this->container = $container;
         $this->normalizer = $this->container->get(NormalizerInterface::class);
 
         if ($this->container->has(ClosureDefinitionCollectorInterface::class)) {
@@ -57,6 +54,10 @@ class ParameterParser
 
     public function parseMethodParameters(string $class, string $method, array $arguments): array
     {
+        if (! $this->methodDefinitionCollector) {
+            return [];
+        }
+
         $definitions = $this->methodDefinitionCollector->getParameters($class, $method);
         return $this->getInjections($definitions, "{$class}::{$method}", $arguments);
     }

--- a/src/Factory/ParameterParser.php
+++ b/src/Factory/ParameterParser.php
@@ -12,10 +12,11 @@ declare(strict_types=1);
 namespace Hyperf\Nano\Factory;
 
 use Closure;
-use Hyperf\Contract\NormalizerInterface;
-use Hyperf\Di\ClosureDefinitionCollectorInterface;
-use Hyperf\Di\MethodDefinitionCollectorInterface;
+use Hyperf\Utils\Str;
 use Psr\Container\ContainerInterface;
+use Hyperf\Contract\NormalizerInterface;
+use Hyperf\Di\MethodDefinitionCollectorInterface;
+use Hyperf\Di\ClosureDefinitionCollectorInterface;
 
 class ParameterParser
 {
@@ -70,7 +71,7 @@ class ParameterParser
         $injections = [];
 
         foreach ($definitions as $pos => $definition) {
-            $value = $arguments[$pos] ?? $arguments[$definition->getMeta('name')] ?? null;
+            $value = $arguments[$pos] ?? $arguments[$definition->getMeta('name')] ?? $arguments[Str::snake($definition->getMeta('name'), '-')] ?? null;
             if ($value === null) {
                 if ($definition->getMeta('defaultValueAvailable')) {
                     $injections[] = $definition->getMeta('defaultValue');


### PR DESCRIPTION
这个 PR 做了以下调整/优化

- 适配 PHP8 语法
- 支持 `--with-enable` 赋值给参数 `$withEnable`
- CI 支持 swoole v4.8.11